### PR TITLE
Implemented the enclosure tag like it is specified in RSS 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ foreach($this->podcastRepository->getPublished() as $podcast)
         'guid'        => route('podcast.show', $podcast->slug),
         'url'         => $podcast->media->url(),
         'type'        => $podcast->media_content_type,
+        'length'      => $podcast->media_size,
         'duration'    => $podcast->duration,
         'image'       => $podcast->image->url(),
     ]);
@@ -103,6 +104,7 @@ public function index()
             'guid'        => route('podcast.show', $podcast->slug),
             'url'         => $podcast->media->url(),
             'type'        => $podcast->media_content_type,
+            'length'      => $podcast->media_size,
             'duration'    => $podcast->duration,
             'image'       => $podcast->image->url(),
         ]);

--- a/src/Torann/PodcastFeed/Media.php
+++ b/src/Torann/PodcastFeed/Media.php
@@ -179,11 +179,13 @@ class Media
         $item->appendChild($pubDate);
 
         // Create the <enclosure>
-        $enclosure = $dom->createElement("enclosure");
-        $enclosure->setAttribute("url", $this->url);
-        $enclosure->setAttribute("type", $this->type);
-        $enclosure->setAttribute("length", $this->length);
-        $item->appendChild($enclosure);
+        if($this->url && $this->type && $this->length) {
+            $enclosure = $dom->createElement("enclosure");
+            $enclosure->setAttribute("url", $this->url);
+            $enclosure->setAttribute("type", $this->type);
+            $enclosure->setAttribute("length", $this->length);
+            $item->appendChild($enclosure);
+        }
 
         // Create the author
         if ($this->author) {

--- a/src/Torann/PodcastFeed/Media.php
+++ b/src/Torann/PodcastFeed/Media.php
@@ -55,6 +55,13 @@ class Media
     private $type;
 
     /**
+     * Length of media in bytes
+     *
+     * @var string
+     */
+     private $length;
+
+    /**
      * Author of the media.
      *
      * @var string
@@ -96,6 +103,7 @@ class Media
         $this->url = $this->getValue($data, 'url');
         $this->guid = $this->getValue($data, 'guid');
         $this->type = $this->getValue($data, 'type');
+        $this->length = $this->getValue($data, 'length', 0);
         $this->duration = $this->getValue($data, 'duration');
         $this->author = $this->getValue($data, 'author');
         $this->image = $this->getValue($data, 'image');
@@ -174,6 +182,7 @@ class Media
         $enclosure = $dom->createElement("enclosure");
         $enclosure->setAttribute("url", $this->url);
         $enclosure->setAttribute("type", $this->type);
+        $enclosure->setAttribute("length", $this->length);
         $item->appendChild($enclosure);
 
         // Create the author


### PR DESCRIPTION
in [RSS 2.0](http://cyber.harvard.edu/rss/rss.html#ltenclosuregtSubelementOfLtitemgt) it is specified that the enclosure tag has three required attributes: type, url and lenght

So the length attribute was implemented and if one of the required fields are missing, the enclosure element will not be rendered.